### PR TITLE
renovate update for next versions and update script for no git checks

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,5 +2,10 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:recommended"
+  ],
+  "packageRules": [
+    {
+       "ignoreUnstable": "false"
+    }
   ]
 }

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -10,7 +10,7 @@ if [ ! -z "$VERSION" ]; then
   ## Publish Package
   pnpm version $VERSION -m "Bump version to: %s [skip ci]"
   ## publish to npm
-  pnpm publish
+  pnpm publish --no-git-checks
 
   ## Create GitHub Release
   git push --follow-tags --set-upstream origin $branch


### PR DESCRIPTION
Update renovate to support `next` versions and update to the script for the following error:

npm error Git working directory not clean.
npm error A complete log of this run can be found in: /home/runner/.npm/_logs/[20](https://github.com/player-ui/browser-devtools/actions/runs/9977859358/job/27573468774#step:8:21)24-07-17T16_23_10_762Z-debug-0.log
 ERR_PNPM_GIT_UNCLEAN  Unclean working tree. Commit or stash changes first.

If you want to disable Git checks on publish, set the "git-checks" setting to "false", or run again with "--no-git-checks".

