### PR TITLE
Update env for correct secret

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,7 +33,7 @@ jobs:
       - name: auto version 
         run: pnpm release
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}
 
 
   release:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+# v0.1.1 (Mon Aug 19 2024)
+
+#### 🐛 Bug Fix
+
+- updated to use correct secret ([@mercillo](https://github.com/mercillo))
+
+#### Authors: 1
+
+- Marlon "Marky" Ercillo ([@mercillo](https://github.com/mercillo))
+
+---
+
 # v0.0.14 (Mon Aug 19 2024)
 
 #### ⚠️ Pushed to `main`

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "browser-devtools",
   "displayName": "Player ui devtools",
-  "version": "0.0.13",
+  "version": "0.0.14",
   "description": "Player UI devtools browser extension",
   "author": "Rafael Campos <campos.rb@hotmail.com>",
   "scripts": {


### PR DESCRIPTION
https://intuit.github.io/auto/docs/build-platforms/github-actions#running-with-branch-protection

unable to use just GITHUB_TOKEN with auto.

Using the updated GH_TOKEN that expire on 1/1/25